### PR TITLE
Use dartfmt for dart/flutter

### DIFF
--- a/styles/grandcentrix.xml
+++ b/styles/grandcentrix.xml
@@ -58,6 +58,9 @@
   <AndroidXmlCodeStyleSettings>
     <option name="USE_CUSTOM_SETTINGS" value="true" />
   </AndroidXmlCodeStyleSettings>
+  <DartCodeStyleSettings>
+    <option name="DELEGATE_TO_DARTFMT" value="true" />
+  </DartCodeStyleSettings>
   <JetCodeStyleSettings>
     <option name="PACKAGES_TO_USE_STAR_IMPORTS">
       <value>


### PR DESCRIPTION
Delegate dart formatting to dartfmt instead of the intellij formatting.