### PR TITLE
Adopts supported Blank Line Keeping and Line Wrapping from Java to Kotlin

### DIFF
--- a/styles/grandcentrix.xml
+++ b/styles/grandcentrix.xml
@@ -784,4 +784,14 @@
       </rules>
     </arrangement>
   </codeStyleSettings>
+  <codeStyleSettings language="kotlin">
+    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
+    <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+    <option name="CALL_PARAMETERS_WRAP" value="1" />
+    <option name="METHOD_PARAMETERS_WRAP" value="1" />
+    <option name="EXTENDS_LIST_WRAP" value="1" />
+  </codeStyleSettings>
 </code_scheme>


### PR DESCRIPTION
#### Summary
IntelliJ sets the line wrapping by default to `do not wrap` and the kept blank lines are set to 2.

- To enforce the 120 char line limit the wrapping should be at "if long".
- To reduce unnecessary empty lines the kept blnk lines are reduced to 1. Before a closing curly bracket even to 0.