### PR TITLE
Add offical Kotlin Code Style

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Code formatting rules for Android Studio
   - [Android Lifecycle methods](https://github.com/grandcentrix/AndroidCodeStyle/issues/3) in correct order
   - Methods ([grouped by visibility, a-z](https://github.com/grandcentrix/AndroidCodeStyle/issues/6))
   - static methods (grouped by visibility (except public), a-z)
+ - Official [Kotlin Code Style](https://kotlinlang.org/docs/reference/coding-conventions.html)
 
 ## Installation on your local machine
 

--- a/styles/grandcentrix.xml
+++ b/styles/grandcentrix.xml
@@ -71,6 +71,7 @@
     <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
     <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
     <option name="IMPORT_NESTED_CLASSES" value="true" />
+    <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
   </JetCodeStyleSettings>
   <MarkdownNavigatorCodeStyleSettings>
     <option name="RIGHT_MARGIN" value="-1" />
@@ -785,13 +786,11 @@
     </arrangement>
   </codeStyleSettings>
   <codeStyleSettings language="kotlin">
+    <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
     <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
     <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
     <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
     <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
-    <option name="CALL_PARAMETERS_WRAP" value="1" />
-    <option name="METHOD_PARAMETERS_WRAP" value="1" />
-    <option name="EXTENDS_LIST_WRAP" value="1" />
   </codeStyleSettings>
 </code_scheme>


### PR DESCRIPTION
This will add the official Kotlin Code style to our code style.
Without any changes!
See also http://kotlinlang.org/docs/reference/code-style-migration-guide.html