### PR TITLE
fix mockk star imports

### DIFF
--- a/styles/grandcentrix.xml
+++ b/styles/grandcentrix.xml
@@ -95,7 +95,7 @@
     <option name="PACKAGES_TO_USE_STAR_IMPORTS">
       <value>
         <package name="com.nhaarman.mockito_kotlin" withSubpackages="false" static="false" />
-        <package name="io.mockk.*" withSubpackages="true" static="false" />
+        <package name="io.mockk" withSubpackages="true" static="false" />
         <package name="org.junit" withSubpackages="true" static="false" />
         <package name="org.mockito" withSubpackages="true" static="false" />
         <package name="org.hamcrest" withSubpackages="true" static="false" />


### PR DESCRIPTION
There was an error in the `io.mockk` star imports syntax which caused the star imports to break in Android Studio 3.4.