### PR TITLE
update README part about copying the code style to project

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,6 @@ Code formatting rules for Android Studio
 Just run the [`install`](install.sh) script.
 It will automatically copy the latest Code Style to each existing `AndroidStudio` and `AndroidStudioPreview` version you have installed.
 
-You can also install it directly into an Android Project by running
-```
-$ ./install.sh PATH/TO/YOUT/PROJECT
-```
-
-> **Note:** Before you commit the changes to git make sure you have opened AS/IntelliJ already.
-            The IDE will slightly change the XML after the coping.
-
 ### Manually (the hard way)
 1. Copy the [`grandcentrix.xml`](styles/grandcentrix.xml) into (MacOS) ``~/Library/Preferences/AndroidStudio{VERSION}/codestyles/`` or (Linux) ``~/.AndroidStudio{VERSION}/config/codestyles/``
 2. Restart AndroidStudio
@@ -46,10 +38,11 @@ If the codestyle is added to the git repository and IntelliJ is configured accor
 
 1. Install the [`grandcentrix.xml`](styles/grandcentrix.xml) locally (see above)
 2. Restart AndroidStudio
-3. In AndroidStudio, go to `Preferences --> Code style`
-4. Open the scheme manager by clicking on `Manage...`
-5. Select the code style and click `Copy to project`
-6. In the scheme drop down select `Project`
+3. In AndroidStudio, go to `Preferences --> Editor --> Code style`
+4. Open the scheme list by clicking on the `Scheme:` drop down
+5. From the `Stored in the IDE` section select `grandcentrix`
+6. Click the cogwheel just on the right and select `Copy to project`
+7. Confirm overwriting project settings with the new scheme
 
 Finally add the code style to the git repository:
 ```


### PR DESCRIPTION
Android Studio apparently messes up the code style when it is copied directly to project via the install script.
So the only path to import the code style into a project is to install it for the IDE and then import into the project via Android Studio settings.